### PR TITLE
Add coverlet code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ _TeamCity*
 *.coverage
 *.coveragexml
 
+# Coverlet code coverage result
+test/*/lcov.info
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml

--- a/test/PG.BLLTest/PG.BLLTest.csproj
+++ b/test/PG.BLLTest/PG.BLLTest.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="lcov.info" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
## Summary
It adds [Coverlet](https://github.com/tonerdo/coverlet/) capability to produce code coverage output file during test execution, 
e.g. `dotnet test .\test\PG.BLLTest\PG.BLLTest.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov`.

In Visual Studio Code, we can use an extension like [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) to watch the output file (`lcov.info`) so it can display a nice highlights in the source code to monitor tested/untested lines.