### PR TITLE
Implement Swashbuckle.AspNetCore

### DIFF
--- a/src/PG.Api/Domains/Facility/FacilityController.cs
+++ b/src/PG.Api/Domains/Facility/FacilityController.cs
@@ -30,6 +30,13 @@ namespace PG.Api.Domains.Facility
         }
 
         [Authorize]
+        [HttpPost("base")]
+        public override IActionResult Post([FromBody] NewFacilityDto value, string createdAtRouteName)
+        {
+            return base.Post(value, createdAtRouteName);
+        }
+
+        [Authorize]
         [HttpPut("{id}")]
         public override ActionResult<FacilityDto> Put(int id, [FromBody] EditFacilityDto value)
         {

--- a/src/PG.Api/Domains/Site/SiteController.cs
+++ b/src/PG.Api/Domains/Site/SiteController.cs
@@ -33,6 +33,13 @@ namespace PG.Api.Domains.Site
             return base.Post(value, "GetSiteById");
         }
 
+        //[Authorize]
+        [HttpPost("base")]
+        public override IActionResult Post([FromBody] NewSiteDto value, string createdAtRouteName)
+        {
+            return base.Post(value, createdAtRouteName);
+        }
+
         [Authorize]
         [HttpPut("{id}")]
         public override ActionResult<SiteDto> Put(int id, [FromBody] EditSiteDto value)

--- a/src/PG.Api/Domains/UserProfile/UserProfileController.cs
+++ b/src/PG.Api/Domains/UserProfile/UserProfileController.cs
@@ -23,10 +23,24 @@ namespace PG.Api.Domains.UserProfile
         }
 
         [Authorize]
+        [HttpPost("")]
+        public override IActionResult Post([FromBody] UserProfileDto value, string createdAtRouteName)
+        {
+            return base.Post(value, "GetUserProfileById");
+        }
+
+        [Authorize]
         [HttpPut("{id}")]
         public override ActionResult<UserProfileDto> Put(int id, [FromBody] EditUserProfileDto value)
         {
             return base.Put(id, value);
+        }
+
+        [Authorize]
+        [HttpDelete("{id}")]
+        public override IActionResult Delete(int id)
+        {
+            return base.Delete(id);
         }
 
         [Authorize]

--- a/src/PG.Api/PG.Api.csproj
+++ b/src/PG.Api/PG.Api.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PG.Api/Startup.cs
+++ b/src/PG.Api/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using PG.Api.DIConfigs;
 using PG.DataAccess;
 using PG.Model.Identity;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace PG.Api
 {
@@ -43,6 +44,11 @@ namespace PG.Api
             services.RegisterAppServices();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            services.AddSwaggerGen(s =>
+            {
+                s.SwaggerDoc("v1", new Info { Title = "Playground Core API", Version = "v1" });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -56,6 +62,14 @@ namespace PG.Api
             {
                 app.UseHsts();
             }
+
+            app.UseSwagger();
+
+            app.UseSwaggerUI(s =>
+            {
+                s.SwaggerEndpoint("/swagger/v1/swagger.json", "Playground Core API - v1");
+                s.RoutePrefix = string.Empty;
+            });
 
             app.UseHttpsRedirection();
             app.UseMvc();


### PR DESCRIPTION
I am using Swashbuckle.AspNetCore to wire Swagger into the project. It has a Swagger generator that builds Swagger document objects directly from the routes, controllers, and models.
After initial setup, the project successfully compiled. But, it got error in Swagger part that says

`NotSupportedException: Ambiguous HTTP method for action - PG.Api.Domains.Facility.FacilityController.Post (PG.Api). Actions require an explicit HttpMethod binding for Swagger 2.0`

The comple stack trace 

```
NotSupportedException: Ambiguous HTTP method for action - PG.Api.Domains.Facility.FacilityController.Post (PG.Api). Actions require an explicit HttpMethod binding for Swagger 2.0
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.CreatePathItem(IEnumerable<ApiDescription> apiDescriptions, ISchemaRegistry schemaRegistry)
System.Linq.Enumerable.ToDictionary<TSource, TKey, TElement>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.CreatePathItems(IEnumerable<ApiDescription> apiDescriptions, ISchemaRegistry schemaRegistry)
Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwagger(string documentName, string host, string basePath, string[] schemes)
Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext)
Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
```

I did some research and found it seems that the virtual method in BaseController is related to the cause.
Let's see the FacilityController as example:

- It has 3 endpoints that override the BaseController's method and already explicitly bound HttpMethod: Get(), Put(), Delete()

- It defined it's own endpoint that already explicitly bound HttpMethod: Post()
But, it seems that swagger generator also see the BaseController.Post as FacilityController's method (of course, because it is derived from BaseController). And BaseController.Post does not explicitly bound HttpMethod.

One of workaround I found is override all BaseController virutal method on it's child.
So, what we have to change is on the class that derived from BaseController.
For example in FacilityController, we have to add endpoint that override the BaseController.Post
```
[Authorize]
[HttpPost("base")]
public override IActionResult Post([FromBody] NewFacilityDto value, string createdAtRouteName)
{
return base.Post(value, createdAtRouteName);
}
```
Of course, we have to define different route because there is already another HttpPost endpoint there.
So, what do you think about this solution?